### PR TITLE
Allow users to manage their own email address

### DIFF
--- a/updates/99-fas.update
+++ b/updates/99-fas.update
@@ -13,6 +13,10 @@ dn: cn=users,cn=accounts,$SUFFIX
 add:aci: (targetattr = "nsAccountLock || fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasCreationTime || fasStatusNote")(targetfilter = "(objectclass=fasuser)")(version 3.0;acl "Read FAS user attributes";allow (compare,read,search) userdn = "ldap:///all";)
 add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId")(version 3.0;acl "Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 
+# self-service permissions to allow users to modify their own mail address
+dn: $SUFFIX
+add:aci: (targetattr = "mail")(version 3.0;acl "selfservice:Users can manage their own email address";allow (write) userdn = "ldap:///self";)
+
 # Index for FAS user attributes attribute
 dn: cn=fasIRCNick,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default:cn: fasIRCNick


### PR DESCRIPTION
Add a selfservice ACI to allow users to maintain their own email
address.

Fixes: https://github.com/fedora-infra/freeipa-fas/issues/77
Signed-off-by: Christian Heimes <cheimes@redhat.com>