### PR TITLE
Allow users to remove themselves from groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ User object is extended by the new *fasUser* object class.
 * ``Read FAS user attributes``
 * ``Users can modify their own FAS attributes``
 * ``Users can modify their own Email address``
+* ``Users can remove themselves as members of groups``
 
 ## Indexes
 

--- a/updates/99-fas.update
+++ b/updates/99-fas.update
@@ -20,6 +20,11 @@ add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId ||
 dn: $SUFFIX
 add:aci: (targetattr = "mail")(version 3.0;acl "selfservice:Users can manage their own email address";allow (write) userdn = "ldap:///self";)
 
+
+# allow members to remove themselves from a group
+dn: cn=groups,cn=accounts,$SUFFIX
+add:aci: (targetattr = "member")(targetfilter = "(objectclass=ipaUserGroup)")(version 3.0; acl "Allow members to remove themselves"; allow (selfwrite) userattr = "member#USERDN";)
+
 # Index for FAS user attributes attribute
 dn: cn=fasIRCNick,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default:cn: fasIRCNick


### PR DESCRIPTION
Adds an ACI that allows users to remove themselves from a group.

ACI written by @tiran in
https://github.com/fedora-infra/securitas/issues/108#issuecomment-585718220

Related: https://github.com/fedora-infra/securitas/issues/108

Signed-off-by: Ryan Lerch <rlerch@redhat.com>