### PR TITLE
Sync group membership with member managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,17 @@ User object is extended by the new *fasUser* object class.
 * *fasGitHubUsername*: string, writable by self
 * *fasGitLabUsername*: string, writable by self
 
-### ACIs
+## Groups
+
+* ``group_remove_member`` also removes member managers
+
+## ACIs
 
 * ``Read FAS user attributes``
 * ``Users can modify their own FAS attributes``
 * ``Users can modify their own Email address``
 * ``Users can remove themselves as members of groups``
+* ``Member managers can remove themselves as member managers of groups``
 
 ## Indexes
 

--- a/install.sh
+++ b/install.sh
@@ -22,5 +22,8 @@ python3 -m compileall ${SITE_PACKAGES}/ipaserver/plugins/
 if [ $NEEDS_UPGRADE = 1 ]; then
     ipa-server-upgrade
 else
+    ipa-ldap-updater \
+        -S /usr/share/ipa/schema.d/99-fasschema.ldif \
+        /usr/share/ipa/updates/99-fas.update
     systemctl restart httpd.service
 fi

--- a/ipaserver/plugins/groupfas.py
+++ b/ipaserver/plugins/groupfas.py
@@ -1,0 +1,30 @@
+#
+# FreeIPA plugin for Fedora Account System
+# Copyright (C) 2019  Christian Heimes <cheimes@redhat.com>
+# See COPYING for license
+#
+"""FreeIPA plugin for Fedora Account System
+
+Modify group behavior
+"""
+from ipaserver.plugins.group import group_remove_member
+
+
+def group_remove_member_fas_postcb(
+    self, ldap, completed, failed, dn, entry_attrs, *keys, **options
+):
+    """Also remove user from member manager attribute
+    """
+    if "user" in options:
+        result = self.api.Command.group_remove_member_manager(
+            keys[0], user=options["user"]
+        )
+        if result["completed"]:
+            # one or more member managers were removed, update the entry
+            entry_attrs.pop("membermanager", None)
+            newentry = ldap.get_entry(dn, ["membermanager"])
+            entry_attrs.update(newentry)
+    return completed, dn
+
+
+group_remove_member.register_post_callback(group_remove_member_fas_postcb)

--- a/updates/99-fas.update
+++ b/updates/99-fas.update
@@ -20,10 +20,10 @@ add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId ||
 dn: $SUFFIX
 add:aci: (targetattr = "mail")(version 3.0;acl "selfservice:Users can manage their own email address";allow (write) userdn = "ldap:///self";)
 
-
-# allow members to remove themselves from a group
+# allow members and member managers to remove themselves from a group
 dn: cn=groups,cn=accounts,$SUFFIX
 add:aci: (targetattr = "member")(targetfilter = "(objectclass=ipaUserGroup)")(version 3.0; acl "Allow members to remove themselves"; allow (selfwrite) userattr = "member#USERDN";)
+add:aci: (targetattr = "memberManager")(targetfilter = "(objectclass=ipaUserGroup)")(version 3.0; acl "Allow member managers to remove themselves"; allow (selfwrite) userattr = "memberManager#USERDN";)
 
 # Index for FAS user attributes attribute
 dn: cn=fasIRCNick,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config


### PR DESCRIPTION
Add a new ACI to allow group member managers to remove themselves from
member manager list.

Make group_remove_member also remove the user from member managers.

Signed-off-by: Christian Heimes <cheimes@redhat.com>