### PR TITLE
Make IRC nick a multi-valued string

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ User object is extended by the new *fasUser* object class.
 
 * *fasTimeZone*: string, writable by self
 * *fasLocale*: string, writable by self
-* *fasIRCNick*: string, writable by self, indexed
+* *fasIRCNick*: multi-valued string, writable by self, indexed
 * *fasGPGKeyId*: multi-valued string, writable by self, indexec
 * *fasCreationTime*: timestamp, writable by admin
 * *fasStatusNote*: string, writable by admin

--- a/ipaserver/plugins/userfas.py
+++ b/ipaserver/plugins/userfas.py
@@ -44,7 +44,7 @@ user.takes_params += (
         maxlength=64,
     ),
     Str(
-        "fasircnick?",
+        "fasircnick*",
         cli_name="fasircnick",
         label=_("IRC nick name"),
         maxlength=64,

--- a/schema.d/99-fasschema.ldif
+++ b/schema.d/99-fasschema.ldif
@@ -12,7 +12,7 @@ dn: cn=schema
 # user extension
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.1 NAME 'fasTimezone' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.2 NAME 'fasLocale' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
-attributeTypes: ( 1.3.6.1.4.1.30401.1.1.3 NAME 'fasIRCNick' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.3 NAME 'fasIRCNick' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.4 NAME 'fasGPGKeyId' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{16} X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.5 NAME 'fasCreationTime' EQUALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.6 NAME 'fasStatusNote' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )


### PR DESCRIPTION
Allow users to store multiple IRC nicks.

Changing an attribute from single-valued to multi-valued is backwards
compatible and does not require a reinstallation of IPA.

Fixes: https://github.com/fedora-infra/freeipa-fas/issues/8
Signed-off-by: Christian Heimes <cheimes@redhat.com>