### PR TITLE
Enforce uniqueness of mail address

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ User object is extended by the new *fasUser* object class.
 
 * Index on ``fasIRCNick`` for presence and equality
 * Index on ``fasGPGKeyId`` for presence and equality
+* Uniqueness of ``mail`` attributes
 
 ## Command line extension
 

--- a/updates/99-fas.update
+++ b/updates/99-fas.update
@@ -46,3 +46,22 @@ default:nsSystemIndex: false
 default:nsIndexType: eq
 default:nsIndexType: pres
 
+# ensure that email addresses are unique
+dn: cn=mail uniqueness,cn=plugins,cn=config
+default:objectClass: top
+default:objectClass: nsSlapdPlugin
+default:objectClass: extensibleObject
+default:cn: mail uniqueness
+default:nsslapd-pluginDescription: Enforce unique attribute values
+default:nsslapd-pluginPath: libattr-unique-plugin
+default:nsslapd-pluginInitfunc: NSUniqueAttr_Init
+default:nsslapd-pluginType: preoperation
+default:nsslapd-pluginEnabled: on
+default:uniqueness-attribute-name: mail
+default:uniqueness-subtrees: $SUFFIX
+default:uniqueness-exclude-subtrees: cn=compat,$SUFFIX
+default:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
+default:nsslapd-plugin-depends-on-type: database
+default:nsslapd-pluginId: NSUniqueAttr
+default:nsslapd-pluginVersion: 1.1.0
+default:nsslapd-pluginVendor: Fedora Project


### PR DESCRIPTION
Mail addresses are not unique by default. This breaks the assumption
that an email address is a unique identifier and is only assigned to a
single user.

The mail attribute is already indexed by default.

Signed-off-by: Christian Heimes <cheimes@redhat.com>