### PR TITLE
add top level hidden group

### DIFF
--- a/schema.d/99-fasschema.ldif
+++ b/schema.d/99-fasschema.ldif
@@ -20,3 +20,13 @@ attributeTypes: ( 1.3.6.1.4.1.30401.1.1.7 NAME 'fasRHBZEmail' EQUALITY caseIgnor
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.8 NAME 'fasGitHubUsername' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.9 NAME 'fasGitLabUsername' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername ) X-ORIGIN 'Fedora Account System' )
+
+dn: cn=hidden-groups,ou=groups
+changetype: add
+objectClass: top
+objectClass: group
+
+dn: cn=hidden-groups,ou=groups
+changeType: modify
+add: member
+member: cn=ipausers,ou=groups


### PR DESCRIPTION
@tiran Hi! Mind taking a look at this?

The idea is we want to have a top level group which we can enroll any groups we want as members. The first one of those we've identified is `ipausers` so I am trying to add that here. It runs successfully with `ipa-server-upgrade` but I don't see any of the new information once complete.

So, basically:

1. Create a group `hidden-groups`
2. Add `ipausers` as a member of `hidden-groups`

Signed-off-by: Stephen Coady <scoady@redhat.com>