### PR TITLE
Revert "Enforce uniqueness for staged user area"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ This also applies to stage users.
 * Index on ``fasIRCNick`` for presence and equality
 * Index on ``fasGPGKeyId`` for presence and equality
 * Uniqueness of ``mail`` attributes
-* Uniqueness of ``uid``, ``krbPrincipalName``, ``krbCanonicalName``,
-  and ``ipaUniqueID`` is also enforced for staged users.
 
 ## Command line extension
 

--- a/updates/99-fas.update
+++ b/updates/99-fas.update
@@ -60,21 +60,8 @@ default:nsslapd-pluginEnabled: on
 default:uniqueness-attribute-name: mail
 default:uniqueness-subtrees: $SUFFIX
 default:uniqueness-exclude-subtrees: cn=compat,$SUFFIX
-remove:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
+default:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
 default:nsslapd-plugin-depends-on-type: database
 default:nsslapd-pluginId: NSUniqueAttr
 default:nsslapd-pluginVersion: 1.1.0
 default:nsslapd-pluginVendor: Fedora Project
-
-# also ensure uniqueness for staged users
-dn: cn=uid uniqueness,cn=plugins,cn=config
-remove:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
-
-dn: cn=krbPrincipalName uniqueness,cn=plugins,cn=config
-remove:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
-
-dn: cn=krbCanonicalName uniqueness,cn=plugins,cn=config
-remove:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
-
-dn: cn=ipaUniqueID uniqueness,cn=plugins,cn=config
-remove:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX


### PR DESCRIPTION
This reverts commit 9ded969fb491aa47e1d8f23df1baa361305cf327.

stageuser_activate does not modrdn (rename) the stage entry. It creates
a new entry and then removes the stage entry. This causes conflicts.

See: https://github.com/fedora-infra/freeipa-fas/issues/93