### PR TITLE
Manually ensure unique login and email

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ $ ipa user-mod --help
 
 The `ipa stageuser-add` command is extended in the same way.
 
+Stage user plugin ensures that a stage user does not have the same
+login or email address as another user (active, staged, or deleted).
+
 The group add, modification, and find commands have an additional
 option ``--fasgroup``.
 

--- a/ipaserver/plugins/baseruserfas.py
+++ b/ipaserver/plugins/baseruserfas.py
@@ -1,0 +1,91 @@
+#
+# FreeIPA plugin for Fedora Account System
+# Copyright (C) 2020  Christian Heimes <cheimes@redhat.com>
+# See COPYING for license
+#
+"""FreeIPA plugin for Fedora Account System
+
+Common user extensions
+"""
+from ipalib import _
+from ipalib.parameters import DateTime, Str
+
+from ipaserver.plugins.baseuser import baseuser
+from ipaserver.plugins.internal import i18n_messages
+
+# possible object classes and default attributes are shared between all
+# users plugins.
+baseuser.possible_objectclasses.append("fasuser")
+
+default_attributes = [
+    "fastimezone",
+    "faslocale",
+    "fasircnick",
+    "fasgpgkeyid",
+    "fasstatusnote",
+    "fascreationtime",
+    "fasrhbzemail",
+    "fasgithubusername",
+    "fasgitlabusername",
+]
+baseuser.default_attributes.extend(default_attributes)
+
+takes_params = (
+    Str(
+        "fastimezone?",
+        cli_name="fastimezone",
+        label=_("user timezone"),
+        maxlength=64,
+    ),
+    Str(
+        "faslocale?",
+        cli_name="faslocale",
+        label=_("user locale"),
+        maxlength=64,
+    ),
+    Str(
+        "fasircnick*",
+        cli_name="fasircnick",
+        label=_("IRC nick name"),
+        maxlength=64,
+    ),
+    Str(
+        "fasgpgkeyid*",
+        cli_name="fasgpgkeyid",
+        label=_("GPG Key ids"),
+        maxlength=16,
+    ),
+    Str(
+        "fasstatusnote?",
+        cli_name="fasstatusnote",
+        label=_("User status note"),
+    ),
+    DateTime(
+        "fascreationtime?",
+        cli_name="fascreationtime",
+        label=_("user creation time"),
+    ),
+    Str(
+        "fasrhbzemail?",
+        cli_name="fasrhbzemail",
+        label=_("Red Hat bugzilla email"),
+        maxlength=255,
+        normalizer=lambda value: value.strip(),
+    ),
+    Str(
+        "fasgithubusername?",
+        cli_name="fasgithubusername",
+        label=_("GitHub username"),
+        maxlength=255,
+        normalizer=lambda value: value.strip(),
+    ),
+    Str(
+        "fasgitlabusername?",
+        cli_name="fasgitlabusername",
+        label=_("GitLab username"),
+        maxlength=255,
+        normalizer=lambda value: value.strip(),
+    ),
+)
+
+i18n_messages.messages["userfas"] = {"name": _("Fedora Account System")}

--- a/ipaserver/plugins/stageuserfas.py
+++ b/ipaserver/plugins/stageuserfas.py
@@ -1,0 +1,110 @@
+#
+# FreeIPA plugin for Fedora Account System
+# Copyright (C) 2020  Christian Heimes <cheimes@redhat.com>
+# See COPYING for license
+#
+"""FreeIPA plugin for Fedora Account System
+
+Stage user extension
+"""
+from ipalib import _
+from ipalib import errors
+
+from ipaserver.plugins.stageuser import stageuser
+from ipaserver.plugins.stageuser import stageuser_add
+from ipaserver.plugins.stageuser import stageuser_mod
+
+from .baseruserfas import takes_params
+from .userfas import user_add_fas_precb, user_mod_fas_precb
+
+# same procedure as standard user
+stageuser.takes_params += takes_params
+
+stageuser_add.register_pre_callback(user_add_fas_precb)
+stageuser_mod.register_pre_callback(user_mod_fas_precb)
+
+
+def _check_conflict(self, ldap, dn, entry, operation):
+    """Check for conflicting login and email address
+
+    The stageuser_activate plugin does not modrdn the stage user to active
+    user. Instead it first creates a new active user DN and then deletes the
+    stage user DN. All uniqueness plugins have to exclude stage user area and
+    FAS has to manually check for conflicts.
+    """
+    unique_attrs = ["uid", "krbprincipalname", "krbcanonicalname", "mail"]
+
+    if operation == "add":
+        attr_filters = ldap.make_filter(
+            {attr: entry[attr] for attr in unique_attrs}, rules=ldap.MATCH_ANY
+        )
+    elif operation == "mod":
+        entry["uid"] = dn["uid"]
+        attr_filters = ldap.make_filter(
+            {attr: entry[attr] for attr in unique_attrs if attr in entry},
+            rules=ldap.MATCH_ANY,
+        )
+    else:
+        raise ValueError(operation)
+
+    objcls_filters = ldap.make_filter(
+        {"objectclass": ["posixaccount", "inetOrgPerson"]},
+        rules=ldap.MATCH_ANY,
+    )
+    filters = ldap.combine_filters(
+        [objcls_filters, attr_filters], rules=ldap.MATCH_ALL
+    )
+
+    try:
+        res, truncated = ldap.find_entries(
+            filters,
+            unique_attrs,
+            base_dn=self.api.env.basedn,
+            scope=ldap.SCOPE_SUBTREE,
+        )
+    except errors.NotFound:
+        pass
+    else:
+        for conflict_entry in res:
+            if conflict_entry.dn == dn:
+                # skip own entry
+                continue
+            if "mail" in entry:
+                raise errors.DuplicateEntry(
+                    message=_(
+                        "Login '%(user)s' or email address '%(mail)s' are "
+                        "already registered."
+                    )
+                    % {"user": entry["uid"], "mail": ", ".join(entry["mail"])}
+                )
+            else:
+                # mod operation
+                raise errors.DuplicateEntry(
+                    message=_("Login '%(user)s' is already registered.")
+                    % {"user": entry["uid"]}
+                )
+
+
+def stageuser_add_fas_precb(
+    self, ldap, dn, entry, attrs_list, *keys, **options
+):
+    """Verify that uid, mail, and krb principal are not in use
+    """
+    _check_conflict(self, ldap, dn, entry, operation="add")
+    return dn
+
+
+stageuser_add.register_pre_callback(stageuser_add_fas_precb)
+
+
+def stageuser_mod_fas_precb(
+    self, ldap, dn, entry, attrs_list, *keys, **options
+):
+    """Verify that uid, mail, and krb principal are not in use
+    """
+    print(entry)
+    _check_conflict(self, ldap, dn, entry, operation="mod")
+    return dn
+
+
+stageuser_mod.register_pre_callback(stageuser_mod_fas_precb)

--- a/ipaserver/plugins/userfas.py
+++ b/ipaserver/plugins/userfas.py
@@ -7,94 +7,14 @@
 """
 from ipalib import _
 from ipalib import errors
-from ipalib.parameters import DateTime, Str
 
 from ipaserver.plugins.user import user
 from ipaserver.plugins.user import user_add
 from ipaserver.plugins.user import user_mod
-from ipaserver.plugins.stageuser import stageuser
-from ipaserver.plugins.stageuser import stageuser_add
-from ipaserver.plugins.stageuser import stageuser_mod
-from ipaserver.plugins.internal import i18n_messages
 
-user.possible_objectclasses.append("fasuser")
-stageuser.possible_objectclasses.append("fasuser")
+from .baseruserfas import takes_params
 
-default_attributes = [
-    "fastimezone",
-    "faslocale",
-    "fasircnick",
-    "fasgpgkeyid",
-    "fasstatusnote",
-    "fascreationtime",
-    "fasrhbzemail",
-    "fasgithubusername",
-    "fasgitlabusername",
-]
-user.default_attributes.extend(default_attributes)
-stageuser.default_attributes.extend(default_attributes)
-
-takes_params = (
-    Str(
-        "fastimezone?",
-        cli_name="fastimezone",
-        label=_("user timezone"),
-        maxlength=64,
-    ),
-    Str(
-        "faslocale?",
-        cli_name="faslocale",
-        label=_("user locale"),
-        maxlength=64,
-    ),
-    Str(
-        "fasircnick*",
-        cli_name="fasircnick",
-        label=_("IRC nick name"),
-        maxlength=64,
-    ),
-    Str(
-        "fasgpgkeyid*",
-        cli_name="fasgpgkeyid",
-        label=_("GPG Key ids"),
-        maxlength=16,
-    ),
-    Str(
-        "fasstatusnote?",
-        cli_name="fasstatusnote",
-        label=_("User status note"),
-    ),
-    DateTime(
-        "fascreationtime?",
-        cli_name="fascreationtime",
-        label=_("user creation time"),
-    ),
-    Str(
-        "fasrhbzemail?",
-        cli_name="fasrhbzemail",
-        label=_("Red Hat bugzilla email"),
-        maxlength=255,
-        normalizer=lambda value: value.strip(),
-    ),
-    Str(
-        "fasgithubusername?",
-        cli_name="fasgithubusername",
-        label=_("GitHub username"),
-        maxlength=255,
-        normalizer=lambda value: value.strip(),
-    ),
-    Str(
-        "fasgitlabusername?",
-        cli_name="fasgitlabusername",
-        label=_("GitLab username"),
-        maxlength=255,
-        normalizer=lambda value: value.strip(),
-    ),
-)
 user.takes_params += takes_params
-stageuser.takes_params += takes_params
-
-i18n_messages.messages["userfas"] = {"name": _("Fedora Account System")}
 
 
 def check_fasuser_attr(entry):
@@ -119,7 +39,6 @@ def user_add_fas_precb(self, ldap, dn, entry, attrs_list, *keys, **options):
 
 
 user_add.register_pre_callback(user_add_fas_precb)
-stageuser_add.register_pre_callback(user_add_fas_precb)
 
 
 def user_mod_fas_precb(self, ldap, dn, entry, attrs_list, *keys, **options):
@@ -136,4 +55,3 @@ def user_mod_fas_precb(self, ldap, dn, entry, attrs_list, *keys, **options):
 
 
 user_mod.register_pre_callback(user_mod_fas_precb)
-stageuser_mod.register_pre_callback(user_mod_fas_precb)

--- a/updates/99-fas.update
+++ b/updates/99-fas.update
@@ -65,3 +65,20 @@ default:nsslapd-plugin-depends-on-type: database
 default:nsslapd-pluginId: NSUniqueAttr
 default:nsslapd-pluginVersion: 1.1.0
 default:nsslapd-pluginVendor: Fedora Project
+
+# TODO: Remove this block before stable release
+# see https://github.com/fedora-infra/freeipa-fas/issues/93
+dn: cn=mail uniqueness,cn=plugins,cn=config
+add:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
+
+dn: cn=uid uniqueness,cn=plugins,cn=config
+add:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
+
+dn: cn=krbPrincipalName uniqueness,cn=plugins,cn=config
+add:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
+
+dn: cn=krbCanonicalName uniqueness,cn=plugins,cn=config
+add:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX
+
+dn: cn=ipaUniqueID uniqueness,cn=plugins,cn=config
+add:uniqueness-exclude-subtrees: cn=staged users,cn=accounts,cn=provisioning,$SUFFIX


### PR DESCRIPTION
The stageuser_activate plugin does not modrdn the stage user to active
user. Instead it first creates a new active user DN and then deletes the
stage user DN. All uniqueness plugins have to exclude stage user area and
FAS has to manually check for conflicts.

Fixes: https://github.com/fedora-infra/freeipa-fas/issues/89
See: https://github.com/fedora-infra/freeipa-fas/issues/93
Signed-off-by: Christian Heimes <cheimes@redhat.com>