### PR TITLE
Add group attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 BLACK=black -l78
+JSL=jsl -nologo -nosummary
 
 all: lint
 
 lint:
 	$(BLACK) --check .
-	jsl -nologo -nosummary -process ui/js/plugins/userfas/userfas.js
+	$(JSL) -process ui/js/plugins/userfas/userfas.js
+	$(JSL) -process ui/js/plugins/groupfas/groupfas.js
 
 black:
 	$(BLACK) .

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ groups.
   don't have the *fasGroup* object class.
 * ``group_remove_member`` also removes member managers
 
+Groups with the *fasGroup* object class have the following optional attributes:
+
+* *fasURL*: multi-valued string
+* *fasIRCChannel*: string
+* *fasMailingList*: string
+
 ## ACIs
 
 * ``Read FAS user attributes``
@@ -55,6 +61,7 @@ groups.
 * ``Users can modify their own Email address``
 * ``Users can remove themselves as members of groups``
 * ``Member managers can remove themselves as member managers of groups``
+* ``Read FAS group attributes``
 
 ## User settings
 

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,8 @@ cp updates/99-fas.update /usr/share/ipa/updates/
 
 mkdir -p -m 755 /usr/share/ipa/ui/js/plugins/userfas
 cp ui/js/plugins/userfas/userfas.js /usr/share/ipa/ui/js/plugins/userfas/
+mkdir -p -m 755 /usr/share/ipa/ui/js/plugins/groupfas
+cp ui/js/plugins/groupfas/groupfas.js /usr/share/ipa/ui/js/plugins/groupfas/
 
 cp ipaserver/plugins/*.py ${SITE_PACKAGES}/ipaserver/plugins/
 python3 -m compileall ${SITE_PACKAGES}/ipaserver/plugins/

--- a/ipaserver/plugins/baseruserfas.py
+++ b/ipaserver/plugins/baseruserfas.py
@@ -17,7 +17,8 @@ from .fasutils import URL
 
 # possible object classes and default attributes are shared between all
 # users plugins.
-baseuser.possible_objectclasses.append("fasuser")
+if "fasuser" not in baseuser.possible_objectclasses:
+    baseuser.possible_objectclasses.append("fasuser")
 
 default_attributes = [
     "fastimezone",

--- a/ipaserver/plugins/fasutils.py
+++ b/ipaserver/plugins/fasutils.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 from ipalib.parameters import Str
+from ipalib.ipavalidate import Email as valid_email
 
 
 class URL(Str):
@@ -22,3 +23,26 @@ class URL(Str):
         if not url.netloc:
             return _("empty host name")
         return None
+
+
+class Email(Str):
+    kwargs = Str.kwargs + (("email", bool, True),)
+
+    def _rule_email(self, _, value):
+        if not valid_email(value):
+            return _("Invalid email address")
+        return None
+
+
+class IRCChannel(Str):
+    kwargs = Str.kwargs + (("ircurl", bool, True),)
+
+    def _rule_ircurl(self, _, value):
+        return None
+
+    def _convert_scalar(self, value, index=None):
+        value = super()._convert_scalar(value, index)
+        value = value.lstrip("#")
+        if not value.startswith("irc:"):
+            value = "irc:///{}".format(value)
+        return value

--- a/ipaserver/plugins/groupfas.py
+++ b/ipaserver/plugins/groupfas.py
@@ -8,7 +8,7 @@
 Modify group behavior
 """
 from ipalib import _
-from ipalib.parameters import Flag, Str
+from ipalib.parameters import Flag
 from ipaserver.plugins.group import group
 from ipaserver.plugins.group import group_add
 from ipaserver.plugins.group import group_find
@@ -50,9 +50,9 @@ group.takes_params += (
         label=_("FAS group"),
         flags={"virtual_attribute", "no_create", "no_update", "no_search"},
     ),
-    URL("fasurl*", cli_name="fasurl", label=_("Group URL"), maxlength=255,),
+    URL("fasurl?", cli_name="fasurl", label=_("Group URL"), maxlength=255,),
     Email(
-        "fasmailinglist*",
+        "fasmailinglist?",
         cli_name="fasmailinglist",
         label=_("Mailing list address"),
         maxlength=255,

--- a/ipaserver/plugins/groupfas.py
+++ b/ipaserver/plugins/groupfas.py
@@ -183,7 +183,7 @@ def group_mod_fas_precb(self, ldap, dn, entry, *keys, **options):
             entry_oc = ldap.get_entry(dn, ["objectclass"])
             entry["objectclass"] = entry_oc["objectclass"]
         if not self.obj.has_objectclass(entry["objectclass"], "fasgroup"):
-            entry.append("fasgroup")
+            entry["objectclass"].append("fasgroup")
         # check fasgroup attributes
         check_fasgroup_attr(entry)
     return dn
@@ -223,5 +223,5 @@ group_show.register_post_callback(group_show_fas_postcb)
 
 i18n_messages.messages["groupfas"] = {
     "name": _("Fedora Account System"),
-    "group": "FAS Group",
+    "group": _("FAS Group"),
 }

--- a/schema.d/99-fasschema.ldif
+++ b/schema.d/99-fasschema.ldif
@@ -23,7 +23,7 @@ attributeTypes: ( 1.3.6.1.4.1.30401.1.1.10 NAME 'fasWebsiteURL' EQUALITY caseIgn
 objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername $ fasWebsiteURL ) X-ORIGIN 'Fedora Account System' )
 #
 # group extension
-attributeTypes: ( 1.3.6.1.4.1.30401.1.1.20 NAME 'fasURL' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.20 NAME 'fasURL' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.21 NAME 'fasMailingList' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
-attributeTypes: ( 1.3.6.1.4.1.30401.1.1.22 NAME 'fasIRCChannel' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.22 NAME 'fasIRCChannel' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Fedora Account System' )
 objectClasses: ( 1.3.6.1.4.1.30401.1.2.2 NAME 'fasGroup' DESC 'FAS group objectclass' SUP ipaUserGroup AUXILIARY MAY ( fasURL $ fasMailingList $ fasIRCChannel ) X-ORIGIN 'Fedora Account System' )

--- a/schema.d/99-fasschema.ldif
+++ b/schema.d/99-fasschema.ldif
@@ -23,7 +23,7 @@ attributeTypes: ( 1.3.6.1.4.1.30401.1.1.10 NAME 'fasWebsiteURL' EQUALITY caseIgn
 objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername $ fasWebsiteURL ) X-ORIGIN 'Fedora Account System' )
 #
 # group extension
-attributeTypes: ( 1.3.6.1.4.1.30401.1.1.10 NAME 'fasURL' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Fedora Account System' )
-attributeTypes: ( 1.3.6.1.4.1.30401.1.1.11 NAME 'fasMailingList' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
-attributeTypes: ( 1.3.6.1.4.1.30401.1.1.12 NAME 'fasIRCChannel' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.20 NAME 'fasURL' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.21 NAME 'fasMailingList' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.22 NAME 'fasIRCChannel' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 objectClasses: ( 1.3.6.1.4.1.30401.1.2.2 NAME 'fasGroup' DESC 'FAS group objectclass' SUP ipaUserGroup AUXILIARY MAY ( fasURL $ fasMailingList $ fasIRCChannel ) X-ORIGIN 'Fedora Account System' )

--- a/schema.d/99-fasschema.ldif
+++ b/schema.d/99-fasschema.ldif
@@ -23,4 +23,7 @@ attributeTypes: ( 1.3.6.1.4.1.30401.1.1.10 NAME 'fasWebsiteURL' EQUALITY caseIgn
 objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername $ fasWebsiteURL ) X-ORIGIN 'Fedora Account System' )
 #
 # group extension
-objectClasses: ( 1.3.6.1.4.1.30401.1.2.2 NAME 'fasGroup' DESC 'FAS group objectclass' SUP ipaUserGroup AUXILIARY X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.10 NAME 'fasURL' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.11 NAME 'fasMailingList' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.12 NAME 'fasIRCChannel' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
+objectClasses: ( 1.3.6.1.4.1.30401.1.2.2 NAME 'fasGroup' DESC 'FAS group objectclass' SUP ipaUserGroup AUXILIARY MAY ( fasURL $ fasMailingList $ fasIRCChannel ) X-ORIGIN 'Fedora Account System' )

--- a/ui/js/plugins/groupfas/groupfas.js
+++ b/ui/js/plugins/groupfas/groupfas.js
@@ -1,0 +1,48 @@
+//
+// FreeIPA plugin for Fedora Account System
+// Copyright (C) 2019  Christian Heimes <cheimes@redhat.com>
+// See COPYING for license
+//
+
+define([
+        'freeipa/phases',
+        'freeipa/ipa'
+    ],
+    function(phases, IPA) {
+
+        // helper function
+        function get_item(array, attr, value) {
+
+            for (var i = 0, l = array.length; i < l; i++) {
+                if (array[i][attr] === value) return array[i];
+            }
+            return null;
+        }
+
+        var groupfas_plugin = {};
+
+        groupfas_plugin.add_user_fas_pre_op = function() {
+            var section = {
+                name: 'groupfas',
+                label: '@i18n:groupfas.name',
+                fields: [{
+                    name: 'fasurl',
+                    $type: 'multivalued',
+                    flags: ['w_if_no_aci']
+                }, {
+                    name: 'fasmailinglist',
+                    flags: ['w_if_no_aci']
+                }, {
+                    name: 'fasircchannel',
+                    flags: ['w_if_no_aci']
+                }]
+            };
+            var facet = get_item(IPA.group.entity_spec.facets, '$type', 'details');
+            facet.sections.push(section);
+            return true;
+        };
+
+        phases.on('customization', groupfas_plugin.add_user_fas_pre_op);
+
+        return groupfas_plugin;
+    });

--- a/ui/js/plugins/groupfas/groupfas.js
+++ b/ui/js/plugins/groupfas/groupfas.js
@@ -21,11 +21,15 @@ define([
 
         var groupfas_plugin = {};
 
-        groupfas_plugin.add_user_fas_pre_op = function() {
+        groupfas_plugin.add_group_fas_pre_op = function() {
             var section = {
                 name: 'groupfas',
                 label: '@i18n:groupfas.name',
                 fields: [{
+                    name: 'fasgroup',
+                    $type: 'checkbox',
+                    flags: ['w_if_no_aci']
+                },{
                     name: 'fasurl',
                     $type: 'multivalued',
                     flags: ['w_if_no_aci']
@@ -42,7 +46,19 @@ define([
             return true;
         };
 
-        phases.on('customization', groupfas_plugin.add_user_fas_pre_op);
+        groupfas_plugin.add_search_group_fas = function() {
+            var fasgroup = {
+                name: 'fasgroup',
+                label: '@i18n:groupfas.fasgroup',
+                formatter: 'boolean_status',
+            };
+            var facet = get_item(IPA.group.entity_spec.facets, '$type', 'search');
+            facet['columns'].splice(1, 0, fasgroup);
+            return true;
+        };
+
+        phases.on('customization', groupfas_plugin.add_group_fas_pre_op);
+        phases.on('customization', groupfas_plugin.add_search_group_fas);
 
         return groupfas_plugin;
     });

--- a/ui/js/plugins/groupfas/groupfas.js
+++ b/ui/js/plugins/groupfas/groupfas.js
@@ -1,6 +1,6 @@
 //
 // FreeIPA plugin for Fedora Account System
-// Copyright (C) 2019  Christian Heimes <cheimes@redhat.com>
+// Copyright (C) 2020  FAS Contributors
 // See COPYING for license
 //
 
@@ -49,8 +49,8 @@ define([
         groupfas_plugin.add_search_group_fas = function() {
             var fasgroup = {
                 name: 'fasgroup',
-                label: '@i18n:groupfas.fasgroup',
-                formatter: 'boolean_status',
+                label: '@i18n:groupfas.group',
+                formatter: 'boolean_status'
             };
             var facet = get_item(IPA.group.entity_spec.facets, '$type', 'search');
             facet['columns'].splice(1, 0, fasgroup);

--- a/updates/99-fas.update
+++ b/updates/99-fas.update
@@ -31,6 +31,11 @@ dn: cn=groups,cn=accounts,$SUFFIX
 add:aci: (targetattr = "member")(targetfilter = "(objectclass=ipaUserGroup)")(version 3.0; acl "Allow members to remove themselves"; allow (selfwrite) userattr = "member#USERDN";)
 add:aci: (targetattr = "memberManager")(targetfilter = "(objectclass=ipaUserGroup)")(version 3.0; acl "Allow member managers to remove themselves"; allow (selfwrite) userattr = "memberManager#USERDN";)
 
+# ACI to expose FAS group attributes
+dn: cn=groups,cn=accounts,$SUFFIX
+add:aci: (targetattr = "fasURL || fasMailingList || fasIRCChannel")(targetfilter = "(objectclass=fasgroup)")(version 3.0;acl "Read FAS group attributes";allow (compare,read,search) userdn = "ldap:///all";)
+
+
 # Index for FAS user attributes attribute
 dn: cn=fasIRCNick,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default:cn: fasIRCNick

--- a/updates/99-fas.update
+++ b/updates/99-fas.update
@@ -31,11 +31,6 @@ dn: cn=groups,cn=accounts,$SUFFIX
 add:aci: (targetattr = "member")(targetfilter = "(objectclass=ipaUserGroup)")(version 3.0; acl "Allow members to remove themselves"; allow (selfwrite) userattr = "member#USERDN";)
 add:aci: (targetattr = "memberManager")(targetfilter = "(objectclass=ipaUserGroup)")(version 3.0; acl "Allow member managers to remove themselves"; allow (selfwrite) userattr = "memberManager#USERDN";)
 
-# ACI to expose FAS group attributes
-dn: cn=groups,cn=accounts,$SUFFIX
-add:aci: (targetattr = "fasURL || fasMailingList || fasIRCChannel")(targetfilter = "(objectclass=fasgroup)")(version 3.0;acl "Read FAS group attributes";allow (compare,read,search) userdn = "ldap:///all";)
-
-
 # Index for FAS user attributes attribute
 dn: cn=fasIRCNick,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default:cn: fasIRCNick
@@ -98,3 +93,6 @@ default:objectClass: groupOfPrincipals
 default:objectClass: ipaKrb5DelegationACL
 default:cn: fasjson-http-delegation
 default:ipaAllowedTarget: cn=ipa-ldap-delegation-targets,cn=s4u2proxy,cn=etc,$SUFFIX
+
+# Update Permissions (keep this at the bottom of the file)
+plugin: update_managed_permissions


### PR DESCRIPTION
Fixes #7

I kept the URL field multi-valued, because I suppose groups could have multiple URLs but maybe that's not the case (WDYT @ryanlerch ?)

I'm not entirely sure about the filter that turns IRC channel names into [the draft](https://www.w3.org/Addressing/draft-mirashi-url-irc-01.txt) that @tiran referred to, but it seems to work.

Since attributes are defined independently from objectclasses, I wonder if it would not be better to use a single "fasIRC" attribute definition for both users and groups. What's the best practices like, Christian?