### PR TITLE
Managed permission

### DIFF
--- a/ipaserver/plugins/baseruserfas.py
+++ b/ipaserver/plugins/baseruserfas.py
@@ -19,7 +19,7 @@ from .fasutils import URL
 # users plugins.
 baseuser.possible_objectclasses.append("fasuser")
 
-default_attributes = [
+fas_user_attributes = [
     "fastimezone",
     "faslocale",
     "fasircnick",
@@ -31,7 +31,7 @@ default_attributes = [
     "fasgitlabusername",
     "faswebsiteurl",
 ]
-baseuser.default_attributes.extend(default_attributes)
+baseuser.default_attributes.extend(fas_user_attributes)
 
 takes_params = (
     Str(

--- a/ipaserver/plugins/userfas.py
+++ b/ipaserver/plugins/userfas.py
@@ -12,9 +12,31 @@ from ipaserver.plugins.user import user
 from ipaserver.plugins.user import user_add
 from ipaserver.plugins.user import user_mod
 
-from .baseruserfas import takes_params
+from .baseruserfas import takes_params, fas_user_attributes
 
 user.takes_params += takes_params
+
+user.managed_permissions.update(
+    {
+        "System: Read FAS user attributes": {
+            "replaces_global_anonymous_aci": True,
+            "ipapermbindruletype": "all",
+            "ipapermright": {"read", "search", "compare"},
+            "ipapermtargetfilter": ["(objectclass=fasuser)"],
+            "ipapermdefaultattr": {"nsAccountLock"}.union(
+                fas_user_attributes
+            ),
+        },
+        # not yet supported
+        # "System: Self-Modify FAS user attributes": {
+        #     "replaces_global_anonymous_aci": True,
+        #     "ipapermright": {"write"},
+        #     "ipapermtargetfilter": ["(objectclass=fasuser)"],
+        #     "ipapermbindruletype": "self",
+        #     "ipapermdefaultattr": fas_user_attributes.copy(),
+        # },
+    },
+)
 
 
 def check_fasuser_attr(entry):

--- a/updates/99-fas.update
+++ b/updates/99-fas.update
@@ -14,17 +14,21 @@ only:ipaUserAuthType: otp
 
 # ACI to expose FAS user attributes
 dn: cn=users,cn=accounts,$SUFFIX
+# read access is now handled by managed permission
 remove:aci: (targetattr = "nsAccountLock || fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasCreationTime || fasStatusNote")(targetfilter = "(objectclass=fasuser)")(version 3.0;acl "Read FAS user attributes";allow (compare,read,search) userdn = "ldap:///all";)
 remove:aci: (targetattr = "nsAccountLock || fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasCreationTime || fasStatusNote || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername")(targetfilter = "(objectclass=fasuser)")(version 3.0;acl "Read FAS user attributes";allow (compare,read,search) userdn = "ldap:///all";)
-add:aci: (targetattr = "nsAccountLock || fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasCreationTime || fasStatusNote || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL")(targetfilter = "(objectclass=fasuser)")(version 3.0;acl "Read FAS user attributes";allow (compare,read,search) userdn = "ldap:///all";)
+remove:aci: (targetattr = "nsAccountLock || fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasCreationTime || fasStatusNote || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL")(targetfilter = "(objectclass=fasuser)")(version 3.0;acl "Read FAS user attributes";allow (compare,read,search) userdn = "ldap:///all";)
 
+# write access is now a self-service permission
 remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId")(version 3.0;acl "Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername")(version 3.0;acl "Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
-add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL")(version 3.0;acl "Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
+remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL")(version 3.0;acl "Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 
 # self-service permissions to allow users to modify their own mail address
+# and their own FAS attributes
 dn: $SUFFIX
 add:aci: (targetattr = "mail")(version 3.0;acl "selfservice:Users can manage their own email address";allow (write) userdn = "ldap:///self";)
+add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 
 # allow members and member managers to remove themselves from a group
 dn: cn=groups,cn=accounts,$SUFFIX
@@ -93,3 +97,6 @@ default:objectClass: groupOfPrincipals
 default:objectClass: ipaKrb5DelegationACL
 default:cn: fasjson-http-delegation
 default:ipaAllowedTarget: cn=ipa-ldap-delegation-targets,cn=s4u2proxy,cn=etc,$SUFFIX
+
+# Update Permissions (keep this at the bottom of the file)
+plugin: update_managed_permissions


### PR DESCRIPTION
Use managaged permisions for read access and self-service permissions
for self-write access. IPA does not (yet) support managed permissions
with self-write bind rule.

Signed-off-by: Christian Heimes <cheimes@redhat.com>