### PR TITLE
Make it possible to choose the fasgroup type in the UI

### DIFF
--- a/ipaserver/plugins/groupfas.py
+++ b/ipaserver/plugins/groupfas.py
@@ -222,6 +222,7 @@ def group_show_fas_postcb(self, ldap, dn, entry_attrs, *keys, **options):
 group_show.register_post_callback(group_show_fas_postcb)
 
 i18n_messages.messages["groupfas"] = {
-    "name": _("Fedora Account System"),
+    "section": _("Fedora Account System"),
     "group": _("FAS Group"),
+    "make_fasgroup": _("Change to FAS group"),
 }

--- a/ui/js/plugins/groupfas/groupfas.js
+++ b/ui/js/plugins/groupfas/groupfas.js
@@ -6,9 +6,10 @@
 
 define([
         'freeipa/phases',
-        'freeipa/ipa'
+        'freeipa/ipa',
+        'freeipa/reg'
     ],
-    function(phases, IPA) {
+    function(phases, IPA, reg) {
 
         // helper function
         function get_item(array, attr, value) {
@@ -24,7 +25,7 @@ define([
         groupfas_plugin.add_group_fas_pre_op = function() {
             var section = {
                 name: 'groupfas',
-                label: '@i18n:groupfas.name',
+                label: '@i18n:groupfas.section',
                 fields: [{
                     name: 'fasgroup',
                     $type: 'checkbox',
@@ -42,7 +43,38 @@ define([
                 }]
             };
             var facet = get_item(IPA.group.entity_spec.facets, '$type', 'details');
+            // Add the details sections
             facet.sections.push(section);
+            // Add the make_fasgroup action
+            facet.actions.push('make_fasgroup');
+            facet.header_actions.splice(-1, 0, 'make_fasgroup');
+
+            /*
+             * Now the add dialog
+             */
+            // Add the fasgroup checkbox on the adder dialog
+            IPA.group.entity_spec.adder_dialog.fields.push({
+                $type: 'checkbox',
+                name: 'fasgroup'
+            });
+            // Override the dialog factory to use the checkbox's data
+            IPA.fasgroup_adder_dialog = function(spec) {
+                var that = IPA.group_adder_dialog(spec);
+                var super_create_command = that.create_add_command;
+                that.create_add_command = function(record) {
+                    var command = super_create_command(record);
+                    // If the ckeckbox is checked, add the fasgroup command option
+                    var fasgroup_field = that.fields.get_field('fasgroup');
+                    var fasgroup = fasgroup_field.save()[0];
+                    if (fasgroup) {
+                        command.set_option("fasgroup", true);
+                    }
+                    return command;
+                };
+                return that;
+            }
+            IPA.group.entity_spec.adder_dialog["$factory"] = IPA.fasgroup_adder_dialog;
+
             return true;
         };
 
@@ -59,6 +91,26 @@ define([
 
         phases.on('customization', groupfas_plugin.add_group_fas_pre_op);
         phases.on('customization', groupfas_plugin.add_search_group_fas);
+
+        function make_fasgroup_action(spec) {
+            spec = spec || {};
+            spec.name = spec.name || 'make_fasgroup';
+            spec.method = spec.method || 'mod';
+            spec.label = spec.label || '@i18n:groupfas.make_fasgroup';
+            spec.needs_confirm = spec.needs_confirm !== undefined ? spec.needs_confirm : true;
+            spec.disable_cond = spec.disable_cond || ['oc_fasgroup'];
+            spec.options = spec.options || {
+                fasgroup: true
+            };
+
+            var that = IPA.object_action(spec);
+
+            return that;
+        }
+
+        phases.on('registration', function() {
+            reg.action.register('make_fasgroup', make_fasgroup_action);
+        });
 
         return groupfas_plugin;
     });


### PR DESCRIPTION
- add a checkbox on the group add dialog
- add an action to convert a generic group to a fasgroup

It's very hackish because I'm touching JS stuff that I'm not sure about.
I tried to make the "FAS group" checkbox editable, but it does not seem to work.
It also seems that converting to a FAS group is a one-way street, I don't see a way to convert back, but maybe we don't need to.

Fixes #102 