### PR TITLE
Add missing semicolon

### DIFF
--- a/ui/js/plugins/groupfas/groupfas.js
+++ b/ui/js/plugins/groupfas/groupfas.js
@@ -72,7 +72,7 @@ define([
                     return command;
                 };
                 return that;
-            }
+            };
             IPA.group.entity_spec.adder_dialog["$factory"] = IPA.fasgroup_adder_dialog;
 
             return true;


### PR DESCRIPTION
```
$ make lint
ui/js/plugins/groupfas/groupfas.js(76): lint warning: missing semicolon
            IPA.group.entity_spec.adder_dialog["$factory"] = IPA.fasgroup_adder_dialog;
```

Signed-off-by: Christian Heimes <cheimes@redhat.com>