### PR TITLE
Improve tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ __pycache__
 ~*
 
 .tox
-node_modules
-package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 BLACK=black -l78
-ESLINT=eslint
 
 all: lint
 
 lint:
 	$(BLACK) --check .
-	$(ESLINT) ui/js/plugins/
 
 black:
 	$(BLACK) .

--- a/tox.ini
+++ b/tox.ini
@@ -24,10 +24,15 @@ commands =
     bandit -r ipaserver/ -ll
 
 [testenv:jslint]
+deps =
+skipsdist = true
+changedir = {envdir}
 whitelist_externals = npm
 commands =
-    npm install eslint@latest
-    {toxinidir}/node_modules/.bin/eslint ui/js/
+    npm install --silent eslint@latest
+    {envdir}/node_modules/.bin/eslint \
+        -c {toxinidir}/.eslintrc.json \
+        {toxinidir}/ui/js/
 
 
 [flake8]


### PR DESCRIPTION
- Don't install Python stuff for jslint target
- Move npm package directory to .tox/jslint
- Remove eslint from Makefile

Signed-off-by: Christian Heimes <cheimes@redhat.com>