### PR TITLE
Show the agreement status when listing agreements

### DIFF
--- a/ipaserver/plugins/fasagreement.py
+++ b/ipaserver/plugins/fasagreement.py
@@ -54,6 +54,7 @@ class fasagreement(LDAPObject):
     default_attributes = [
         "cn",
         "description",
+        "ipaenabledflag",
         "member",
         "memberuser",
     ]


### PR DESCRIPTION
It would be useful to know if an agreement is enabled when listing them, so we don't display disabled agreements.