### PR TITLE
Use correct actions in fasagreement facets

### DIFF
--- a/ui/js/plugins/groupfas/groupfas.js
+++ b/ui/js/plugins/groupfas/groupfas.js
@@ -42,12 +42,25 @@ define([
                     flags: ['w_if_no_aci']
                 }]
             };
+            var fasagreement = {
+                $type: 'association',
+                name: 'memberof_fasagreement',
+                associator: IPA.serial_associator,
+                add_method: 'add_group',
+                add_title: '@i18n:fasagreement.add',
+                remove_method: 'remove_group',
+                remove_title: '@i18n:fasagreement.remove'
+            };
+
             var facet = get_item(IPA.group.entity_spec.facets, '$type', 'details');
             // Add the details sections
             facet.sections.push(section);
             // Add the make_fasgroup action
             facet.actions.push('make_fasgroup');
             facet.header_actions.splice(-1, 0, 'make_fasgroup');
+
+            // Add user agreement add/remove facet
+            IPA.group.entity_spec.facets.push(fasagreement);
 
             /*
              * Now the add dialog

--- a/ui/js/plugins/userfas/userfas.js
+++ b/ui/js/plugins/userfas/userfas.js
@@ -66,9 +66,21 @@ define([
                     flags: ['w_if_no_aci']
                 }]
             };
+            var fasagreement = {
+                $type: 'association',
+                $pre_ops: [IPA.user.association_facet_ss_pre_op],
+                name: 'memberof_fasagreement',
+                associator: IPA.serial_associator,
+                add_method: 'add_user',
+                add_title: '@i18n:fasagreement.add',
+                remove_method: 'remove_user',
+                remove_title: '@i18n:fasagreement.remove'
+            };
             [IPA.user.entity_spec, IPA.stageuser.stageuser_spec].forEach(function(spec) {
               var facet = get_item(spec.facets, '$type', 'details');
               facet.sections.push(section);
+
+              spec.facets.push(fasagreement);
             });
             return true;
         };


### PR DESCRIPTION
Facets default to add_member and remove_member actions. User agreements
use add_user/remove_user for users and add_group/remove_group for
groups.

Signed-off-by: Christian Heimes <cheimes@redhat.com>