### PR TITLE
Add a isPrivate attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BLACK=black -l78
+BLACK=black
 
 all: lint
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ User object is extended by a new *fasUser* object class.
 * *fasTimeZone*: string, writable by self
 * *fasLocale*: string, writable by self
 * *fasIRCNick*: multi-valued string, writable by self, indexed
-* *fasGPGKeyId*: multi-valued string, writable by self, indexec
+* *fasGPGKeyId*: multi-valued string, writable by self, indexed
 * *fasCreationTime*: timestamp, writable by admin
 * *fasStatusNote*: string, writable by admin
 * *fasRHBZEmail*: string, writable by self
 * *fasGitHubUsername*: string, writable by self
 * *fasGitLabUsername*: string, writable by self
 * *fasWebsiteURL*: string, writable by self
+* *fasIsPrivate*: boolean, writable by self
 
 This also applies to stage users.
 

--- a/ipaserver/plugins/baseruserfas.py
+++ b/ipaserver/plugins/baseruserfas.py
@@ -8,7 +8,7 @@
 Common user extensions
 """
 from ipalib import _
-from ipalib.parameters import DateTime, Str
+from ipalib.parameters import DateTime, Str, Bool
 
 from ipaserver.plugins.baseuser import baseuser
 from ipaserver.plugins.internal import i18n_messages
@@ -31,6 +31,7 @@ fas_user_attributes = [
     "fasgithubusername",
     "fasgitlabusername",
     "faswebsiteurl",
+    "fasisprivate",
 ]
 baseuser.default_attributes.extend(fas_user_attributes)
 
@@ -98,6 +99,12 @@ takes_params = (
         label=_("Website / Blog URL"),
         maxlength=255,
         normalizer=lambda value: value.strip(),
+    ),
+    Bool(
+        "fasisprivate?",
+        cli_name="fasisprivate",
+        label=_("Hide personal data"),
+        doc=_("Hide personal data from other users"),
     ),
 )
 

--- a/ipaserver/plugins/fasagreement.py
+++ b/ipaserver/plugins/fasagreement.py
@@ -34,12 +34,21 @@ __doc__ = _(
 
 
 fasagreement_output_params = (
-    Str("memberuser_user?", label="Agreement users",),
-    Str("memberusers?", label=_("Failed members"),),
+    Str(
+        "memberuser_user?",
+        label="Agreement users",
+    ),
+    Str(
+        "memberusers?",
+        label=_("Failed members"),
+    ),
 )
 
 fasagreement_member_output_params = (
-    Str("memberof_fasagreement", label="Member of user agreement",),
+    Str(
+        "memberof_fasagreement",
+        label="Member of user agreement",
+    ),
 )
 
 register = Registry()
@@ -47,8 +56,7 @@ register = Registry()
 
 @register()
 class fasagreement(LDAPObject):
-    """User Agreement object for FAS
-    """
+    """User Agreement object for FAS"""
 
     container_dn = DN(("cn", "fasagreements"))
     object_name = _("Agreement")
@@ -119,9 +127,15 @@ class fasagreement(LDAPObject):
             primary_key=True,
         ),
         Str(
-            "description?", cli_name="desc", label=_("Agreement Description"),
+            "description?",
+            cli_name="desc",
+            label=_("Agreement Description"),
         ),
-        Bool("ipaenabledflag?", label=_("Enabled"), flags=["no_option"],),
+        Bool(
+            "ipaenabledflag?",
+            label=_("Enabled"),
+            flags=["no_option"],
+        ),
     )
 
 
@@ -220,7 +234,10 @@ class _fasagreement_enabledflag(LDAPQuery):
         except errors.EmptyModlist:
             pass
 
-        return dict(result=True, value=pkey_to_value(cn, options),)
+        return dict(
+            result=True,
+            value=pkey_to_value(cn, options),
+        )
 
 
 @register()
@@ -255,8 +272,7 @@ class fasagreement_remove_user(LDAPRemoveMember):
     member_count_out = (_("%i user removed."), _("%i users removed."))
 
     def pre_callback(self, ldap, dn, found, not_found, *keys, **options):
-        """Remove users from linked groups
-        """
+        """Remove users from linked groups"""
         user_uids = [
             user_dn["uid"] for user_dn in found["memberuser"]["user"]
         ]

--- a/ipaserver/plugins/groupfas.py
+++ b/ipaserver/plugins/groupfas.py
@@ -58,7 +58,12 @@ group.takes_params += (
         label=_("FAS group"),
         flags={"virtual_attribute", "no_create", "no_update", "no_search"},
     ),
-    URL("fasurl?", cli_name="fasurl", label=_("Group URL"), maxlength=255,),
+    URL(
+        "fasurl?",
+        cli_name="fasurl",
+        label=_("Group URL"),
+        maxlength=255,
+    ),
     Email(
         "fasmailinglist?",
         cli_name="fasmailinglist",
@@ -102,8 +107,7 @@ group_mod.takes_options += (
 
 
 def check_fasgroup_attr(entry):
-    """Common function to verify fasgroup attributes
-    """
+    """Common function to verify fasgroup attributes"""
     pass
 
 
@@ -129,8 +133,7 @@ def _has_fasgroup_options(options):
 
 
 def group_add_fas_precb(self, ldap, dn, entry, attrs_list, *keys, **options):
-    """Add fasgroup object class and related attributes.
-    """
+    """Add fasgroup object class and related attributes."""
     if _has_fasgroup_options(options):
         if not self.obj.has_objectclass(entry["objectclass"], "fasgroup"):
             entry["objectclass"].append("fasgroup")
@@ -143,8 +146,7 @@ group_add.register_pre_callback(group_add_fas_precb)
 
 
 def group_add_fas_postcb(self, ldap, dn, entry_attrs, *keys, **options):
-    """Include fasgroup membership info
-    """
+    """Include fasgroup membership info"""
     self.obj.get_fasgroup_attribute(entry_attrs, options)
     return dn
 
@@ -155,8 +157,7 @@ group_add.register_post_callback(group_add_fas_postcb)
 def group_find_fas_precb(
     self, ldap, filter, attrs_list, base_dn, scope, criteria=None, **options
 ):
-    """Search filter for FAS group
-    """
+    """Search filter for FAS group"""
     if options.get("fasgroup", False):
         fasfilter = ldap.make_filter(
             {"objectclass": ["fasgroup"]}, rules=ldap.MATCH_ALL
@@ -171,8 +172,7 @@ group_find.register_pre_callback(group_find_fas_precb)
 
 
 def group_find_fas_postcb(self, ldap, entries, truncated, *args, **options):
-    """Search filter for FAS group
-    """
+    """Search filter for FAS group"""
     if not options.get("raw", False):
         for entry in entries:
             self.obj.get_fasgroup_attribute(entry, options)
@@ -183,8 +183,7 @@ group_find.register_post_callback(group_find_fas_postcb)
 
 
 def group_mod_fas_precb(self, ldap, dn, entry, *keys, **options):
-    """Add fasgroup object class and related attributes.
-    """
+    """Add fasgroup object class and related attributes."""
     if _has_fasgroup_options(options):
         # add fasgroup object class
         if "objectclass" not in entry:
@@ -203,8 +202,7 @@ group_mod.register_pre_callback(group_mod_fas_precb)
 def group_remove_member_fas_postcb(
     self, ldap, completed, failed, dn, entry_attrs, *keys, **options
 ):
-    """Also remove user from member manager attribute
-    """
+    """Also remove user from member manager attribute"""
     if "user" in options:
         result = self.api.Command.group_remove_member_manager(
             keys[0], user=options["user"]
@@ -275,8 +273,7 @@ group_add_member.register_pre_callback(group_add_member_fas_precb)
 
 
 def group_show_fas_postcb(self, ldap, dn, entry_attrs, *keys, **options):
-    """Show fasgroup membership info
-    """
+    """Show fasgroup membership info"""
     self.obj.get_fasgroup_attribute(entry_attrs, options)
     return dn
 

--- a/ipaserver/plugins/stageuserfas.py
+++ b/ipaserver/plugins/stageuserfas.py
@@ -88,8 +88,7 @@ def _check_conflict(self, ldap, dn, entry, operation):
 def stageuser_add_fas_precb(
     self, ldap, dn, entry, attrs_list, *keys, **options
 ):
-    """Verify that uid, mail, and krb principal are not in use
-    """
+    """Verify that uid, mail, and krb principal are not in use"""
     _check_conflict(self, ldap, dn, entry, operation="add")
     return dn
 
@@ -100,8 +99,7 @@ stageuser_add.register_pre_callback(stageuser_add_fas_precb)
 def stageuser_mod_fas_precb(
     self, ldap, dn, entry, attrs_list, *keys, **options
 ):
-    """Verify that uid, mail, and krb principal are not in use
-    """
+    """Verify that uid, mail, and krb principal are not in use"""
     print(entry)
     _check_conflict(self, ldap, dn, entry, operation="mod")
     return dn

--- a/ipaserver/plugins/userfas.py
+++ b/ipaserver/plugins/userfas.py
@@ -58,8 +58,7 @@ user_find.takes_options += (
 
 
 def check_fasuser_attr(entry):
-    """Common function to verify fasuser attributes
-    """
+    """Common function to verify fasuser attributes"""
     fasrhbzemail = entry.get("fasrhbzemail")
     if fasrhbzemail is not None and "@" not in fasrhbzemail:
         msg = _("invalid e-mail format: %(email)s")
@@ -100,8 +99,7 @@ user_mod.register_pre_callback(user_mod_fas_precb)
 def user_find_fas_precb(
     self, ldap, filter, attrs_list, base_dn, scope, criteria=None, **options
 ):
-    """Search filter for FAS user
-    """
+    """Search filter for FAS user"""
     if options.get("fasuser", False):
         fasfilter = ldap.make_filter(
             {"objectclass": ["fasuser"]}, rules=ldap.MATCH_ALL

--- a/schema.d/89-fasschema.ldif
+++ b/schema.d/89-fasschema.ldif
@@ -20,7 +20,8 @@ attributeTypes: ( 1.3.6.1.4.1.30401.1.1.7 NAME 'fasRHBZEmail' EQUALITY caseIgnor
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.8 NAME 'fasGitHubUsername' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.9 NAME 'fasGitLabUsername' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.10 NAME 'fasWebsiteURL' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
-objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername $ fasWebsiteURL ) X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.11 NAME 'fasIsPrivate' EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
+objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername $ fasWebsiteURL $ fasIsPrivate ) X-ORIGIN 'Fedora Account System' )
 #
 # group extension
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.20 NAME 'fasURL' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )

--- a/ui/js/plugins/userfas/userfas.js
+++ b/ui/js/plugins/userfas/userfas.js
@@ -58,6 +58,10 @@ define([
                     name: 'fasgpgkeyid',
                     flags: ['w_if_no_aci']
                 }, {
+                    name: 'fasisprivate',
+                    $type: 'checkbox',
+                    flags: ['w_if_no_aci']
+                }, {
                     $type: 'datetime',
                     name: 'fascreationtime',
                     read_only: true

--- a/updates/89-fas.update
+++ b/updates/89-fas.update
@@ -31,7 +31,8 @@ remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId
 # and their own FAS attributes
 dn: $SUFFIX
 add:aci: (targetattr = "mail")(version 3.0;acl "selfservice:Users can manage their own email address";allow (write) userdn = "ldap:///self";)
-add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
+remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
+add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL || fasIsPrivate")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 
 # allow members and member managers to remove themselves from a group
 dn: cn=groups,cn=accounts,$SUFFIX


### PR DESCRIPTION
In FAS, users used to be able to set a `private` settings that would hide some information from other users.
This new attribute is the data part of bringing back that feature, as detailed in fedora-infra/noggin#363.

This changeset contains the commit from #126, I'll rebase it when it's merged.