### PR TITLE
Add Pronoun field as simple freeform string

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ User object is extended by a new *fasUser* object class.
 * *fasGitLabUsername*: string, writable by self
 * *fasWebsiteURL*: string, writable by self
 * *fasIsPrivate*: boolean, writable by self
+* *fasPronoun*: String, writable by self
 
 This also applies to stage users.
 

--- a/ipaserver/plugins/baseruserfas.py
+++ b/ipaserver/plugins/baseruserfas.py
@@ -32,6 +32,7 @@ fas_user_attributes = [
     "fasgitlabusername",
     "faswebsiteurl",
     "fasisprivate",
+    "faspronoun",
 ]
 baseuser.default_attributes.extend(fas_user_attributes)
 
@@ -105,6 +106,12 @@ takes_params = (
         cli_name="fasisprivate",
         label=_("Hide personal data"),
         doc=_("Hide personal data from other users"),
+    ),
+    Str(
+        "faspronoun?",
+        cli_name="faspronoun",
+        label=_("Preferred pronouns"),
+        maxlength=64,
     ),
 )
 

--- a/schema.d/89-fasschema.ldif
+++ b/schema.d/89-fasschema.ldif
@@ -21,7 +21,8 @@ attributeTypes: ( 1.3.6.1.4.1.30401.1.1.8 NAME 'fasGitHubUsername' EQUALITY case
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.9 NAME 'fasGitLabUsername' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.10 NAME 'fasWebsiteURL' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.11 NAME 'fasIsPrivate' EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
-objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername $ fasWebsiteURL $ fasIsPrivate ) X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.12 NAME 'fasPronoun' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
+objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername $ fasWebsiteURL $ fasIsPrivate $ fasPronoun) X-ORIGIN 'Fedora Account System' )
 #
 # group extension
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.20 NAME 'fasURL' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )

--- a/ui/js/plugins/userfas/userfas.js
+++ b/ui/js/plugins/userfas/userfas.js
@@ -68,6 +68,9 @@ define([
                 }, {
                     name: 'fasstatusnote',
                     flags: ['w_if_no_aci']
+                }, {
+                    name: 'faspronoun',
+                    flags: ['w_if_no_aci']
                 }]
             };
             var fasagreement = {

--- a/updates/89-fas.update
+++ b/updates/89-fas.update
@@ -21,6 +21,8 @@ dn: $SUFFIX
 add:aci: (targetattr = "mail")(version 3.0;acl "selfservice:Users can manage their own email address";allow (write) userdn = "ldap:///self";)
 remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL || fasIsPrivate")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
+remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL || fasIsPrivate")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
+add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteURL || fasIsPrivate || fasPronoun")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 
 # allow members and member managers to remove themselves from a group
 dn: cn=groups,cn=accounts,$SUFFIX


### PR DESCRIPTION
This adds a new FAS attribute for being able to
set a user's preferred pronoun(s)

Fixes: fedora-infra/noggin#220

Signed-off-by: Ryan Lerch <rlerch@redhat.com>