### PR TITLE
Fix fasagreement_remove_user in fasagreement.py

### DIFF
--- a/ipaserver/plugins/fasagreement.py
+++ b/ipaserver/plugins/fasagreement.py
@@ -294,12 +294,12 @@ class fasagreement_remove_user(LDAPRemoveMember):
         group_obj = self.api.Object.group
         group_container_dn = DN(group_obj.container_dn, self.api.env.basedn)
         try:
-            entry = ldap.get_entry(dn, ["member"])
+            entry = ldap.get_entry(dn, ["memberuser"])
         except errors.NotFound:
             raise self.obj.handle_not_found(*keys)
         group_names = [
             group_obj.get_primary_key_from_dn(m)
-            for m in entry["member"]
+            for m in entry["memberuser"]
             if m.endswith(group_container_dn)
         ]
         # remove users group groups


### PR DESCRIPTION
The current plugin is unable to remove users from a fas agreement set in IPA, neither from the CLI or from the Web UI. We are met with an internal error. Apache logs will show:

```
[Wed Jan 13 23:05:00.837207 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102] ipa: ERROR: non-public: KeyError: 'member'
[Wed Jan 13 23:05:00.837243 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102] Traceback (most recent call last):
[Wed Jan 13 23:05:00.837250 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipaserver/rpcserver.py", line 395, in wsgi_execute
[Wed Jan 13 23:05:00.837256 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     result = command(*args, **options)
[Wed Jan 13 23:05:00.837261 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipalib/frontend.py", line 450, in __call__
[Wed Jan 13 23:05:00.837267 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     return self.__do_call(*args, **options)
[Wed Jan 13 23:05:00.837272 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipalib/frontend.py", line 478, in __do_call
[Wed Jan 13 23:05:00.837277 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     ret = self.run(*args, **options)
[Wed Jan 13 23:05:00.837283 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipalib/frontend.py", line 800, in run
[Wed Jan 13 23:05:00.837305 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     return self.execute(*args, **options)
[Wed Jan 13 23:05:00.837311 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipaserver/plugins/baseldap.py", line 1800, in execute
[Wed Jan 13 23:05:00.837317 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     dn = callback(self, ldap, dn, member_dns, failed, *keys, **options)
[Wed Jan 13 23:05:00.837322 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipaserver/plugins/fasagreement.py", line 302, in pre_callback
[Wed Jan 13 23:05:00.837328 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     for m in entry["member"]
[Wed Jan 13 23:05:00.837333 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipapython/ipaldap.py", line 508, in __getitem__
[Wed Jan 13 23:05:00.837338 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     return self._get_nice(name)
[Wed Jan 13 23:05:00.837344 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipapython/ipaldap.py", line 475, in _get_nice
[Wed Jan 13 23:05:00.837349 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     name = self._get_attr_name(name)
[Wed Jan 13 23:05:00.837354 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipapython/ipaldap.py", line 471, in _get_attr_name
[Wed Jan 13 23:05:00.837360 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     name = self._names[name]
[Wed Jan 13 23:05:00.837365 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]   File "/usr/lib/python3.6/site-packages/ipapython/ipautil.py", line 655, in __getitem__
[Wed Jan 13 23:05:00.837370 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]     return super(CIDict, self).__getitem__(key.lower())
[Wed Jan 13 23:05:00.837379 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102] KeyError: 'member'
[Wed Jan 13 23:05:00.837390 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102]
[Wed Jan 13 23:05:00.837704 2021] [wsgi:error] [pid 4916:tid 139919478892288] [remote 2001:470:1f19:138::231:42102] ipa: INFO: [jsonserver_session] label@EXAMPLE.COM: fasagreement_remove_user/1('testing', version='2.239', user=('label',)): InternalError
```

The current code in `fasagreement.py` for function `fasagreement_remove_user` is attempting to look for and remove `member` attributes (groups) rather than `memberuser` attributes (users).

```
[root@ipa01 plugins]# ipa fasagreement-show testing --all --raw
  dn: cn=testing,cn=fasagreements,dc=example,dc=com
  cn: testing
  description: testing
  ipaenabledflag: TRUE
  member: cn=testgroup,cn=groups,cn=accounts,dc=example,dc=com
  memberuser: uid=label,cn=users,cn=accounts,dc=example,dc=com
  ipaUniqueID: ...
  objectClass: ipaassociation
  objectClass: fasagreement
```

This PR is a quick two-line fix that fixed the internal errors on my IPA servers.