### PR TITLE
Increase the pagedLookThroughLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,15 @@ $ ipa servicedelegationrule-add-member \
       --principals=HTTP/$(hostname) fasjson-http-delegation
 ```
 
+
+## Server limits
+
+With FASJSON we want to be able to list all users, using a SimplePage query. At
+the moment we have about 120k users and we're hitting the default
+``lookThroughLimit``. We are thus increasing the ``pagedLookThroughLimit`` to
+500k.
+
+
 ## License
 
 See file 'COPYING' for use and warranty information

--- a/updates/89-fas.update
+++ b/updates/89-fas.update
@@ -105,5 +105,10 @@ dn: cn=fasagreements,$SUFFIX
 add:aci: (targetattr = "memberUser")(targetfilter = "(objectclass=fasagreement)")(version 3.0; acl "Forbid users to retract an agreement"; deny (selfwrite) userattr = "memberUser#USERDN";)
 add:aci: (targetattr = "memberUser")(targetfilter = "(&(objectclass=fasagreement)(ipaenabledflag=TRUE))")(version 3.0; acl "Allow users to consent to an agreement"; allow (selfwrite) userdn = "ldap:///all";)
 
+# Set server limits that are more fit for our project size:
+# - increase the pagedLookThroughLimit so we can get all users in FASJSON.
+dn: cn=config,cn=ldbm database,cn=plugins,cn=config
+replace: nsslapd-pagedlookthroughlimit:0::500000
+
 # Update Permissions (keep this at the bottom of the file)
 plugin: update_managed_permissions


### PR DESCRIPTION
With FASJSON we want to be able to list all users, using a SimplePage query. At the moment we have about 120k users and we're hitting the default `lookThroughLimit`. We are thus increasing the `pagedLookThroughLimit` to 500k.

Fixes: fedora-infra/fasjson#133