### PR TITLE
The GPG key ID attribute should be between 16 and 40 chars long

### DIFF
--- a/ipaserver/plugins/baseruserfas.py
+++ b/ipaserver/plugins/baseruserfas.py
@@ -61,7 +61,8 @@ takes_params = (
         "fasgpgkeyid*",
         cli_name="fasgpgkeyid",
         label=_("GPG Key ids"),
-        maxlength=16,
+        minlength=16,
+        maxlength=40,
     ),
     Str(
         "fasstatusnote?",

--- a/schema.d/89-fasschema.ldif
+++ b/schema.d/89-fasschema.ldif
@@ -13,7 +13,7 @@ dn: cn=schema
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.1 NAME 'fasTimezone' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.2 NAME 'fasLocale' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.3 NAME 'fasIRCNick' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Fedora Account System' )
-attributeTypes: ( 1.3.6.1.4.1.30401.1.1.4 NAME 'fasGPGKeyId' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{16} X-ORIGIN 'Fedora Account System' )
+attributeTypes: ( 1.3.6.1.4.1.30401.1.1.4 NAME 'fasGPGKeyId' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{40} X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.5 NAME 'fasCreationTime' EQUALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.6 NAME 'fasStatusNote' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.7 NAME 'fasRHBZEmail' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )


### PR DESCRIPTION
We want to allow full-length fingerprint and disallow the 8 chars long ID which have all been spoofed.