### PR TITLE
Add indexes for the FAS attributes we usually search on

### DIFF
--- a/updates/89-fas.update
+++ b/updates/89-fas.update
@@ -63,6 +63,44 @@ default:ObjectClass: nsIndex
 default:nsSystemIndex: false
 add:nsIndexType: pres
 
+dn: cn=fasCreationTime,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default:cn: fasCreationTime
+default:ObjectClass: top
+default:ObjectClass: nsIndex
+default:nsSystemIndex: false
+default:nsIndexType: eq
+
+dn: cn=fasRHBZEmail,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default:cn: fasRHBZEmail
+default:ObjectClass: top
+default:ObjectClass: nsIndex
+default:nsSystemIndex: false
+default:nsIndexType: eq
+default:nsIndexType: pres
+
+dn: cn=fasGitHubUsername,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default:cn: fasGitHubUsername
+default:ObjectClass: top
+default:ObjectClass: nsIndex
+default:nsSystemIndex: false
+default:nsIndexType: eq
+default:nsIndexType: pres
+
+dn: cn=fasGitLabUsername,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default:cn: fasGitLabUsername
+default:ObjectClass: top
+default:ObjectClass: nsIndex
+default:nsSystemIndex: false
+default:nsIndexType: eq
+default:nsIndexType: pres
+
+dn: cn=fasIsPrivate,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
+default:cn: fasIsPrivate
+default:ObjectClass: top
+default:ObjectClass: nsIndex
+default:nsSystemIndex: false
+default:nsIndexType: eq
+
 # Index account lock, used by search for disabled users
 dn: cn=nsAccountLock,cn=index,cn=userRoot,cn=ldbm database,cn=plugins,cn=config
 default:cn: nsAccountLock


### PR DESCRIPTION
Add directory indexes for the following attributes:
- fasCreationTime (queried by badges)
- fasRHBZEmail (queried by bugzilla2fedmsg)
- fasGitHubUsername (queried by webhook-to-fedora-messaging)
- fasGitLabUsername (will be queried by webhook-to-fedora-messaging)
- fasIsPrivate (queried by FASJSON)