### PR TITLE
Add the c (country) attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ User object is extended by a new *fasUser* object class.
 * *fasIsPrivate*: boolean, writable by self
 * *fasPronoun*: String, writable by self
 * *fasRssUrl*: multi-valued string, writable by self
+* *c*: string, writable by self (country code, ISO 3166-1 alpha-2)
 
 This also applies to stage users.
 
@@ -98,6 +99,7 @@ $ ipa user-mod --help
   --fasstatusnote=STR   User status note
   --fascreationtime=DATETIME
                         user creation time
+  --country=STR         country (ISO 3166-1 alpha-2)
   ...
 ```
 

--- a/ipaserver/plugins/baseruserfas.py
+++ b/ipaserver/plugins/baseruserfas.py
@@ -34,6 +34,7 @@ fas_user_attributes = [
     "fasisprivate",
     "faspronoun",
     "fasrssurl",
+    "c",
 ]
 baseuser.default_attributes.extend(fas_user_attributes)
 
@@ -121,6 +122,16 @@ takes_params = (
         label=_("RSS URL"),
         maxlength=255,
         normalizer=lambda value: value.strip(),
+    ),
+    Str(
+        "c?",
+        cli_name="country",
+        label=_("Country"),
+        doc=_("Country code" " (ISO 3166-1 alpha-2, e.g., US, ES, CH)"),
+        length=2,
+        pattern=r"^[A-Z]{2}$",
+        pattern_errmsg="must be a 2-letter uppercase"
+        " ISO 3166-1 alpha-2 country code",
     ),
 )
 

--- a/ipaserver/plugins/baseruserfas.py
+++ b/ipaserver/plugins/baseruserfas.py
@@ -7,6 +7,7 @@
 
 Common user extensions
 """
+
 from ipalib import _
 from ipalib.parameters import DateTime, Str, Bool
 

--- a/ipaserver/plugins/fasagreement.py
+++ b/ipaserver/plugins/fasagreement.py
@@ -7,6 +7,7 @@
 Member users are stored in "memberUser" attribute while related groups are
 stored in "member" attribute. FreeIPA does not have a "memberGroup" attribute.
 """
+
 from ipalib import Bool, Str
 from ipalib import errors
 from ipalib import output
@@ -27,8 +28,7 @@ from ipalib import _, ngettext
 from ipapython.dn import DN
 from ipaserver.plugins.internal import i18n_messages
 
-__doc__ = _(
-    """
+__doc__ = _("""
 FAS User Agreements
 
 User agreements are a concept where users may need to consent to an
@@ -51,8 +51,7 @@ EXAMPLES:
 
  Consent to an agreement as a user:
    ipa fasagreement-add-user theagreement --user=myuser
-"""
-)
+""")
 
 
 fasagreement_output_params = (

--- a/ipaserver/plugins/groupfas.py
+++ b/ipaserver/plugins/groupfas.py
@@ -7,6 +7,7 @@
 
 Modify group behavior
 """
+
 from ipalib import _
 from ipalib.parameters import Flag
 from ipaserver.plugins.group import group

--- a/ipaserver/plugins/stageuserfas.py
+++ b/ipaserver/plugins/stageuserfas.py
@@ -7,6 +7,7 @@
 
 Stage user extension
 """
+
 from ipalib import _
 from ipalib import errors
 

--- a/ipaserver/plugins/userfas.py
+++ b/ipaserver/plugins/userfas.py
@@ -68,7 +68,7 @@ def check_fasuser_attr(entry):
 
 
 def user_add_fas_precb(self, ldap, dn, entry, attrs_list, *keys, **options):
-    if any(option.startswith("fas") for option in options):
+    if any(option.startswith("fas") for option in options) or "c" in options:
         # add fasuser object class
         if not self.obj.has_objectclass(entry["objectclass"], "fasuser"):
             entry["objectclass"].append("fasuser")
@@ -81,7 +81,7 @@ user_add.register_pre_callback(user_add_fas_precb)
 
 
 def user_mod_fas_precb(self, ldap, dn, entry, attrs_list, *keys, **options):
-    if any(option.startswith("fas") for option in options):
+    if any(option.startswith("fas") for option in options) or "c" in options:
         # add fasuser object class
         if "objectclass" not in entry:
             entry_oc = ldap.get_entry(dn, ["objectclass"])

--- a/ipaserver/plugins/userfas.py
+++ b/ipaserver/plugins/userfas.py
@@ -3,8 +3,8 @@
 # Copyright (C) 2019  FreeIPA FAS Contributors
 # See COPYING for license
 #
-"""FreeIPA plugin for Fedora Account System
-"""
+"""FreeIPA plugin for Fedora Account System"""
+
 from ipalib import _
 from ipalib import errors
 from ipalib.parameters import Flag

--- a/schema.d/89-fasschema.ldif
+++ b/schema.d/89-fasschema.ldif
@@ -23,7 +23,7 @@ attributeTypes: ( 1.3.6.1.4.1.30401.1.1.10 NAME 'fasWebsiteUrl' EQUALITY caseIgn
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.11 NAME 'fasIsPrivate' EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.12 NAME 'fasPronoun' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Fedora Account System' )
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.13 NAME 'fasRssUrl' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'Fedora Account System' )
-objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername $ fasWebsiteUrl $ fasIsPrivate $ fasPronoun $ fasRssUrl) X-ORIGIN 'Fedora Account System' )
+objectClasses: ( 1.3.6.1.4.1.30401.1.2.1 NAME 'fasUser' DESC 'FAS user objectclass' AUXILIARY MAY ( fasTimeZone $ fasLocale $ fasIRCNick $ fasGPGKeyId $ fasCreationTime $ fasStatusNote $ fasRHBZEmail $ fasGitHubUsername $ fasGitLabUsername $ fasWebsiteUrl $ fasIsPrivate $ fasPronoun $ fasRssUrl $ c) X-ORIGIN 'Fedora Account System' )
 #
 # group extension
 attributeTypes: ( 1.3.6.1.4.1.30401.1.1.20 NAME 'fasURL' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Fedora Account System' )

--- a/ui/js/plugins/userfas/userfas.js
+++ b/ui/js/plugins/userfas/userfas.js
@@ -90,6 +90,16 @@ define([
               var facet = get_item(spec.facets, '$type', 'details');
               facet.sections.push(section);
 
+              // Add 'c' (Country) field to the existing mailing section
+              var mailing = get_item(facet.sections, 'name', 'mailing');
+              if (mailing) {
+                  mailing.fields.push({
+                      name: 'c',
+                      label: 'Country',
+                      flags: ['w_if_no_aci']
+                  });
+              }
+
               spec.facets.push(fasagreement);
             });
             return true;

--- a/updates/89-fas.update
+++ b/updates/89-fas.update
@@ -25,6 +25,8 @@ remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId
 add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasIsPrivate || fasPronoun")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasIsPrivate || fasPronoun")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteUrl || fasIsPrivate || fasPronoun || fasRssUrl")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
+remove:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteUrl || fasIsPrivate || fasPronoun || fasRssUrl")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
+add:aci: (targetattr = "fasTimezone || fasLocale || fasIRCNick || fasGPGKeyId || fasRHBZEmail || fasGitHubUsername || fasGitLabUsername || fasWebsiteUrl || fasIsPrivate || fasPronoun || fasRssUrl || c")(version 3.0;acl "selfservice:Users can modify their own FAS attributes";allow (write) userdn = "ldap:///self";)
 
 # allow members and member managers to remove themselves from a group
 dn: cn=groups,cn=accounts,$SUFFIX


### PR DESCRIPTION
To comply with the AlmaLinux OS Foundation's legal obligations, we need to record the user's country, and the simplest way to do it is by adding it to the fas extensions. We think this may be useful in other cases too, so we'd like to propose it as a contribution.

I don't have a lot of experience with FreeIPA, but @abbra has looked it over and he thinks it's good. :)